### PR TITLE
Bump shivammathur/setup-php to v2.37.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@v2.37.1
       with:
         php-version: ${{ matrix.php }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2.37.1
+      uses: shivammathur/setup-php@2.37.1
       with:
         php-version: ${{ matrix.php }}
 


### PR DESCRIPTION
Addresses Dependabot security alert **GHSA-5wxr-w449-57cm** (moderate severity).

The `php.yml` workflow used the floating `shivammathur/setup-php@v2` tag, which Dependabot flagged because it could resolve to a version below the patched `2.37.1`. This pins the action to `v2.37.1`, the patched release.

https://claude.ai/code/session_01QRG98A1Sd5Qs8pj9soFzBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRG98A1Sd5Qs8pj9soFzBp)_